### PR TITLE
Add path filters to GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,10 +21,32 @@
 name: "CI Pipeline"
 
 on:
-  push:
-    branches: ["main"]
   pull_request:
-    branches: ["main"]
+    branches: [main]
+    paths-ignore:
+      - ".github/workflows/terraform.yml"
+      - ".github/workflows/image-cleanup.yml"
+      - ".vscode/**"
+      - "docs/**"
+      - "infrastructure/**"
+      - ".gitignore"
+      - "*.MD"
+      - "LICENSE"
+      - "renovate.json"
+      - "Taskfile.yml"
+  push:
+    branches: [main]
+    paths-ignore:
+      - ".github/workflows/terraform.yml"
+      - ".github/workflows/image-cleanup.yml"
+      - ".vscode/**"
+      - "docs/**"
+      - "infrastructure/**"
+      - ".gitignore"
+      - "*.MD"
+      - "LICENSE"
+      - "renovate.json"
+      - "Taskfile.yml"
 
 # Default permissions (most restrictive)
 permissions: read-all

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,8 +21,30 @@ permissions: read-all
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - ".github/workflows/terraform.yml"
+      - ".github/workflows/image-cleanup.yml"
+      - ".vscode/**"
+      - "docs/**"
+      - "infrastructure/**"
+      - ".gitignore"
+      - "*.MD"
+      - "LICENSE"
+      - "renovate.json"
+      - "Taskfile.yml"
   push:
     branches: [main]
+    paths-ignore:
+      - ".github/workflows/terraform.yml"
+      - ".github/workflows/image-cleanup.yml"
+      - ".vscode/**"
+      - "docs/**"
+      - "infrastructure/**"
+      - ".gitignore"
+      - "*.MD"
+      - "LICENSE"
+      - "renovate.json"
+      - "Taskfile.yml"
   schedule:
     - cron: "0 3 * * 0" # Weekly security scan on Sundays at 3 AM UTC
 

--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -19,10 +19,32 @@ name: "Trivy Security Analysis"
 on:
   pull_request:
     branches: [main]
+    paths-ignore:
+      - ".github/workflows/terraform.yml"
+      - ".github/workflows/image-cleanup.yml"
+      - ".vscode/**"
+      - "docs/**"
+      - "infrastructure/**"
+      - ".gitignore"
+      - "*.MD"
+      - "LICENSE"
+      - "renovate.json"
+      - "Taskfile.yml"
   push:
     branches: [main]
+    paths-ignore:
+      - ".github/workflows/terraform.yml"
+      - ".github/workflows/image-cleanup.yml"
+      - ".vscode/**"
+      - "docs/**"
+      - "infrastructure/**"
+      - ".gitignore"
+      - "*.MD"
+      - "LICENSE"
+      - "renovate.json"
+      - "Taskfile.yml"
   schedule:
-    - cron: '0 2 * * 6' # Weekly security scan on Saturdays at 2 AM UTC (day before CodeQL)
+    - cron: "0 2 * * 6" # Weekly security scan on Saturdays at 2 AM UTC (day before CodeQL)
 
 # Default permissions (most restrictive)
 permissions: read-all
@@ -91,23 +113,23 @@ jobs:
     timeout-minutes: 5
     if: github.event_name != 'schedule'
     permissions:
-      contents: read         # Read repository contents
+      contents: read # Read repository contents
       security-events: write # Upload SARIF results
     strategy:
       matrix:
-          include:
-            - system: "kyber"
-              image: "go-services"
-              dockerfile: "shared/docker/go-services.Dockerfile"
-              build-args: |
-                SYSTEM=kyber
-                RUNTIME_IMAGE_TAG=nonroot
-            - system: "kyber"
-              image: "db-migrations"
-              dockerfile: "shared/docker/golang-migrate.Dockerfile"
-              build-args: |
-                SYSTEM=kyber
-                RUNTIME_IMAGE_TAG=nonroot
+        include:
+          - system: "kyber"
+            image: "go-services"
+            dockerfile: "shared/docker/go-services.Dockerfile"
+            build-args: |
+              SYSTEM=kyber
+              RUNTIME_IMAGE_TAG=nonroot
+          - system: "kyber"
+            image: "db-migrations"
+            dockerfile: "shared/docker/golang-migrate.Dockerfile"
+            build-args: |
+              SYSTEM=kyber
+              RUNTIME_IMAGE_TAG=nonroot
       fail-fast: false
 
     steps:
@@ -163,7 +185,7 @@ jobs:
         image:
           - "kyber/go-services"
           - "kyber/db-migrations"
-      fail-fast: false  # Continue scanning other images if one fails
+      fail-fast: false # Continue scanning other images if one fails
 
     steps:
       - name: Checkout repository
@@ -173,5 +195,5 @@ jobs:
         uses: ./.github/actions/trivy
         with:
           scan-type: image
-          image: 'ghcr.io/kneadcode/coruscant/${{ matrix.image }}:latest'
+          image: "ghcr.io/kneadcode/coruscant/${{ matrix.image }}:latest"
           category: ${{ matrix.image }}


### PR DESCRIPTION
## Summary
- Add consistent `paths-ignore` configuration to CI, CodeQL, and Trivy workflows
- Workflows now skip runs when changes only affect infrastructure, docs, config files, or unrelated workflow files
- Minor formatting improvements (consistent quote styles and indentation)

## Rationale
Prevents unnecessary CI/CD runs for changes that don't affect:
- Other workflow files (`.github/workflows/terraform.yml`, `.github/workflows/image-cleanup.yml`)
- Infrastructure configuration (`infrastructure/`)
- Documentation (`docs/`, `*.MD` files)
- Developer settings (`.vscode/`, `.gitignore`)
- Build configuration (`Taskfile.yml`, `renovate.json`)
- License file

## Impact
- Reduces CI/CD resource usage
- Faster feedback for documentation, infrastructure, and workflow-only PRs
- Consistent behavior across all three workflow files

## Testing
- Verified path filters are identical across all workflows
- Changes follow GitHub Actions best practices for `paths-ignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)