### PR TITLE
Remove workflow_dispatch and make plan PR-only

### DIFF
--- a/.github/workflows/terraform-drift-detection.yml
+++ b/.github/workflows/terraform-drift-detection.yml
@@ -12,21 +12,12 @@
 #
 # Schedule:
 # - Weekly on Mondays at 8 AM SGT (0:00 UTC Monday)
-# - Manual trigger available for on-demand checks (main branch only)
 
 name: "OpenTofu Drift Detection"
 
 on:
   schedule:
     - cron: "0 0 * * 1" # Weekly on Mondays at 8 AM SGT (0:00 UTC Monday = 8 AM SGT)
-  workflow_dispatch: # Manual trigger (main branch only)
-    inputs:
-      workspace:
-        description: "Specific workspace to check (leave empty for all)"
-        required: false
-        type: choice
-        options:
-          - governance
 
 # Default permissions (most restrictive - jobs override as needed)
 permissions: {}
@@ -38,39 +29,12 @@ env:
 
 jobs:
   # =============================================================================
-  # SECURITY CHECK: ENFORCE MAIN BRANCH FOR MANUAL WORKFLOWS
-  # =============================================================================
-  check-branch:
-    name: "Security: Enforce Main Branch for Manual Workflows"
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    if: github.event_name == 'workflow_dispatch'
-    permissions:
-      contents: read
-
-    steps:
-      - name: Verify workflow_dispatch only on main branch
-        run: |
-          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            echo "::error::Manual workflow dispatch is only allowed on main branch"
-            echo "::error::Current branch: ${{ github.ref }}"
-            echo "::error::Required branch: refs/heads/main"
-            echo ""
-            echo "::error::This is a security restriction to prevent unauthorized drift detection with admin credentials."
-            echo "::error::Please switch to the main branch before manually triggering this workflow."
-            exit 1
-          fi
-          echo "✅ Branch check passed: Running on main branch"
-
-  # =============================================================================
   # DETECT ALL WORKSPACES TO SCAN
   # =============================================================================
   detect-workspaces:
     name: "Detect Workspaces"
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [check-branch]
-    if: ${{ !failure() && !cancelled() }}
     permissions:
       contents: read
     outputs:
@@ -85,22 +49,15 @@ jobs:
       - name: Detect workspaces
         id: detect
         run: |
-          if [[ -n "${{ inputs.workspace }}" ]]; then
-            # Manual trigger with specific workspace
-            echo "workspaces=${{ inputs.workspace }}" >> $GITHUB_OUTPUT
-            echo "count=1" >> $GITHUB_OUTPUT
-            echo "matrix={\"workspace\":[\"${{ inputs.workspace }}\"]}" >> $GITHUB_OUTPUT
-          else
-            # Scan all workspaces
-            WORKSPACES=$(find infrastructure/azure/tf -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | jq -R -s -c 'split("\n")[:-1]')
-            WORKSPACE_LIST=$(echo "$WORKSPACES" | jq -r '.[]' | paste -sd "," -)
-            COUNT=$(echo "$WORKSPACES" | jq '. | length')
+          # Scan all workspaces
+          WORKSPACES=$(find infrastructure/azure/tf -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | jq -R -s -c 'split("\n")[:-1]')
+          WORKSPACE_LIST=$(echo "$WORKSPACES" | jq -r '.[]' | paste -sd "," -)
+          COUNT=$(echo "$WORKSPACES" | jq '. | length')
 
-            echo "Scanning workspaces: $WORKSPACE_LIST (count: $COUNT)"
-            echo "workspaces=$WORKSPACE_LIST" >> $GITHUB_OUTPUT
-            echo "count=$COUNT" >> $GITHUB_OUTPUT
-            echo "matrix={\"workspace\":$WORKSPACES}" >> $GITHUB_OUTPUT
-          fi
+          echo "Scanning workspaces: $WORKSPACE_LIST (count: $COUNT)"
+          echo "workspaces=$WORKSPACE_LIST" >> $GITHUB_OUTPUT
+          echo "count=$COUNT" >> $GITHUB_OUTPUT
+          echo "matrix={\"workspace\":$WORKSPACES}" >> $GITHUB_OUTPUT
 
   # =============================================================================
   # DRIFT DETECTION PER WORKSPACE
@@ -217,7 +174,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WORKSPACE: ${{ matrix.workspace }}
           WORKFLOW_RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          TRIGGER_TYPE: ${{ github.event_name == 'schedule' && 'Scheduled Weekly Scan' || 'Manual Trigger' }}
+          TRIGGER_TYPE: Scheduled Weekly Scan
 
       - name: Report Drift Detection Error
         if: steps.drift.outputs.drift_detected == 'error'
@@ -266,7 +223,7 @@ jobs:
           echo "## 🔍 Drift Detection Summary" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Scan Time**: $(date -u +"%Y-%m-%d %H:%M:%S UTC")" >> $GITHUB_STEP_SUMMARY
-          echo "**Trigger**: ${{ github.event_name == 'schedule' && 'Scheduled Weekly Scan' || 'Manual Trigger' }}" >> $GITHUB_STEP_SUMMARY
+          echo "**Trigger**: Scheduled Weekly Scan" >> $GITHUB_STEP_SUMMARY
           echo "**Workspaces Scanned**: ${{ needs.detect-workspaces.outputs.count }}" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -32,16 +32,9 @@
 # - Deletions handled same as additions (remove from .tf files, not via destroy)
 #
 # Pipeline Phases:
-# Phase 1: Validation & Security Scanning (all branches, read-only)
-# Phase 2: Plan Generation (all branches, read-only, posted to PR)
-# Phase 3: Apply (main branch only, admin credentials from azure-infra environment)
-#
-# Security Note - workflow_dispatch inputs:
-# Codacy flags workflow_dispatch inputs as risky for SOFTWARE BUILD workflows where
-# user inputs could affect build artifacts. This is an INFRASTRUCTURE workflow - no
-# build artifacts are produced. Inputs are restricted to workspace selection (choice
-# dropdown, not free text) and protected by branch restrictions + environment secrets.
-# This is the standard pattern for infrastructure automation and is safe.
+# Phase 1: Validation & Security Scanning (PRs only, read-only)
+# Phase 2: Plan Generation (PRs only, read-only, posted to PR)
+# Phase 3: Apply (main branch push only, admin credentials from azure-infra environment)
 #
 # Note: Drift detection runs in separate workflow (terraform-drift-detection.yml)
 
@@ -62,21 +55,6 @@ on:
       - "infrastructure/azure/tf/**/*.tfvars"
       - "infrastructure/azure/tf/**/.terraform.lock.hcl"
       - ".github/workflows/terraform.yml"
-  workflow_dispatch: # Manual trigger for plan or apply
-    inputs:
-      workspace:
-        description: "Workspace to operate on"
-        required: true
-        type: choice
-        options:
-          - governance
-      action:
-        description: "Action to perform (only apply allowed, destroy via PR)"
-        required: true
-        type: choice
-        options:
-          - plan
-          - apply
 
 # Default permissions (most restrictive - jobs override as needed)
 permissions: {}
@@ -88,39 +66,12 @@ env:
 
 jobs:
   # =============================================================================
-  # SECURITY CHECK: ENFORCE MAIN BRANCH FOR MANUAL WORKFLOWS
-  # =============================================================================
-  check-branch:
-    name: "Security: Enforce Main Branch for Manual Workflows"
-    runs-on: ubuntu-latest
-    timeout-minutes: 1
-    if: github.event_name == 'workflow_dispatch'
-    permissions:
-      contents: read
-
-    steps:
-      - name: Verify workflow_dispatch only on main branch
-        run: |
-          if [[ "${{ github.ref }}" != "refs/heads/main" ]]; then
-            echo "::error::Manual workflow dispatch is only allowed on main branch"
-            echo "::error::Current branch: ${{ github.ref }}"
-            echo "::error::Required branch: refs/heads/main"
-            echo ""
-            echo "::error::This is a security restriction to prevent unauthorized infrastructure changes."
-            echo "::error::Please switch to the main branch before manually triggering this workflow."
-            exit 1
-          fi
-          echo "✅ Branch check passed: Running on main branch"
-
-  # =============================================================================
   # DETECT CHANGED WORKSPACES & ENFORCE SINGLE-WORKSPACE RULE
   # =============================================================================
   detect-workspaces:
     name: "Detect Changed Workspaces"
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    needs: [check-branch]
-    if: ${{ !failure() && !cancelled() }}
     permissions:
       contents: read
       pull-requests: write # Comment on PR if violation detected
@@ -145,21 +96,6 @@ jobs:
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             BASE_REF="${{ github.event.before }}"
             HEAD_REF="${{ github.sha }}"
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            # Manual trigger - use specified workspace
-            echo "workspaces=${{ inputs.workspace }}" >> $GITHUB_OUTPUT
-            echo "count=1" >> $GITHUB_OUTPUT
-            echo "matrix={\"workspace\":[\"${{ inputs.workspace }}\"]}" >> $GITHUB_OUTPUT
-            exit 0
-          elif [[ "${{ github.event_name }}" == "schedule" ]]; then
-            # Scheduled drift detection - scan all workspaces
-            WORKSPACES=$(find infrastructure/azure/tf -mindepth 1 -maxdepth 1 -type d -exec basename {} \; | jq -R -s -c 'split("\n")[:-1]')
-            WORKSPACE_LIST=$(echo "$WORKSPACES" | jq -r '.[]' | paste -sd "," -)
-            COUNT=$(echo "$WORKSPACES" | jq '. | length')
-            echo "workspaces=$WORKSPACE_LIST" >> $GITHUB_OUTPUT
-            echo "count=$COUNT" >> $GITHUB_OUTPUT
-            echo "matrix={\"workspace\":$WORKSPACES}" >> $GITHUB_OUTPUT
-            exit 0
           fi
 
           # Get changed files in infrastructure/azure/tf/
@@ -219,7 +155,7 @@ jobs:
     name: "Validate (${{ matrix.workspace }})"
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    needs: [check-branch, detect-workspaces]
+    needs: [detect-workspaces]
     if: ${{ !failure() && !cancelled() && needs.detect-workspaces.outputs.workspace_count > 0 }}
     # SECURITY: Uses read-only credentials (no environment needed)
     permissions:
@@ -252,14 +188,14 @@ jobs:
         run: tofu validate
 
   # =============================================================================
-  # PHASE 2: PLAN GENERATION (PR + Push)
+  # PHASE 2: PLAN GENERATION (PRs only)
   # =============================================================================
   plan:
     name: "Plan (${{ matrix.workspace }})"
     runs-on: ubuntu-latest
     timeout-minutes: 15
     needs: [detect-workspaces, validate]
-    if: ${{ !failure() && !cancelled() && needs.detect-workspaces.outputs.workspace_count > 0 }}
+    if: ${{ !failure() && !cancelled() && needs.detect-workspaces.outputs.workspace_count > 0 && github.event_name == 'pull_request' }}
     environment: azure-tf-plan # SECURITY: Uses read-only credentials (can plan but not apply)
     permissions:
       contents: read
@@ -345,14 +281,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     needs: [detect-workspaces, validate]
-    # SECURITY: Only allow apply on main branch, never on feature branches
+    # SECURITY: Only allow apply on main branch push, never on feature branches
     # Feature branches use read-only credentials, cannot modify infrastructure
     if: |
       github.ref == 'refs/heads/main' &&
-      (
-        (github.event_name == 'push') ||
-        (github.event_name == 'workflow_dispatch' && github.event.inputs.action == 'apply')
-      ) && !failure() && !cancelled() && needs.detect-workspaces.outputs.workspace_count > 0
+      github.event_name == 'push' &&
+      !failure() && !cancelled() && needs.detect-workspaces.outputs.workspace_count > 0
     environment: azure-tf-apply # SECURITY: Use environment to restrict secret access to main branch only
     permissions:
       contents: read


### PR DESCRIPTION
## Summary

Simplify Terraform/OpenTofu workflows by removing unused manual triggers and making the plan job execute only on PRs.

## Changes

### terraform.yml
- Removed workflow_dispatch trigger (not being used)
- Removed check-branch job (no longer needed)
- Plan job now only runs on pull requests (not on push to main)
- Apply job simplified to only check for push to main
- Updated comments to reflect PR-only plan execution

### terraform-drift-detection.yml
- Removed workflow_dispatch trigger (not being used)
- Removed check-branch job (no longer needed)
- Always scans all workspaces on weekly schedule
- Updated trigger text to static "Scheduled Weekly Scan"

## Workflow Behavior

**Before:**
- PR: Validation → Security Scan → Plan (with PR comment)
- Push to main: Validation → Security Scan → Plan → Apply

**After:**
- PR: Validation → Security Scan → **Plan** (with PR comment)
- Push to main: Validation → Security Scan → **Apply** (no redundant plan)

## Benefits

1. **Simpler workflows** - removed unused manual trigger functionality
2. **No redundant work** - plan only runs on PRs, not after merge
3. **Cleaner code** - fewer conditional branches and dependencies
4. **Clear separation** - PRs get plans, merges trigger applies

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>