### PR TITLE
Rm setting sub_id at provider

### DIFF
--- a/.github/workflows/opentofu-scheduled.yml
+++ b/.github/workflows/opentofu-scheduled.yml
@@ -75,6 +75,9 @@ jobs:
       matrix: ${{ fromJson(needs.detect-workspaces.outputs.matrix) }}
       fail-fast: false # Continue scanning other workspaces if one fails
     env:
+      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_READONLY }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_FOUNDATION }}
       TF_VAR_entra_tenant_id: ${{ secrets.ARM_TENANT_ID }}
       TF_VAR_subscription_id_foundation: ${{ secrets.ARM_SUBSCRIPTION_ID_FOUNDATION }}
       TF_VAR_subscription_id_management: ${{ secrets.ARM_SUBSCRIPTION_ID_MANAGEMENT }}

--- a/.github/workflows/opentofu.yml
+++ b/.github/workflows/opentofu.yml
@@ -204,6 +204,9 @@ jobs:
       matrix: ${{ fromJson(needs.detect-workspaces.outputs.workspace_matrix) }}
       fail-fast: false
     env:
+      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_READONLY }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_FOUNDATION }}
       TF_VAR_entra_tenant_id: ${{ secrets.ARM_TENANT_ID }}
       TF_VAR_subscription_id_foundation: ${{ secrets.ARM_SUBSCRIPTION_ID_FOUNDATION }}
       TF_VAR_subscription_id_management: ${{ secrets.ARM_SUBSCRIPTION_ID_MANAGEMENT }}
@@ -309,6 +312,9 @@ jobs:
       matrix: ${{ fromJson(needs.detect-workspaces.outputs.workspace_matrix) }}
       fail-fast: false
     env:
+      ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+      ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_ADMIN }}
+      ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_FOUNDATION }}
       TF_VAR_entra_tenant_id: ${{ secrets.ARM_TENANT_ID }}
       TF_VAR_subscription_id_foundation: ${{ secrets.ARM_SUBSCRIPTION_ID_FOUNDATION }}
       TF_VAR_subscription_id_management: ${{ secrets.ARM_SUBSCRIPTION_ID_MANAGEMENT }}

--- a/.github/workflows/trivy-scheduled.yml
+++ b/.github/workflows/trivy-scheduled.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           working-directory: ${{ matrix.path }}
           scan-type: fs
-          category: ${{ matrix.module }}-scheduled
+          category: ${{ matrix.module }}
 
   # =============================================================================
   # Trivy-IaC - Infrastructure as Code Analysis
@@ -77,7 +77,6 @@ jobs:
         uses: ./.github/actions/trivy
         with:
           scan-type: config
-          category: scheduled
 
   # =============================================================================
   # Trivy-Registry - Published Container Images (Scheduled Only)
@@ -106,4 +105,4 @@ jobs:
         with:
           scan-type: image
           image: "ghcr.io/kneadcode/coruscant/${{ matrix.image }}:latest"
-          category: ${{ matrix.image }}-registry
+          category: ${{ matrix.image }}

--- a/infrastructure/azure/tf/governance/init.tf
+++ b/infrastructure/azure/tf/governance/init.tf
@@ -37,7 +37,11 @@ provider "azurerm" {
     }
   }
 
-  subscription_id = var.subscription_id_foundation
+  # When managing Management Groups and moving subscriptions:
+  # - Set ARM_SUBSCRIPTION_ID environment variable (for auth context)
+  # - Do NOT hardcode subscription_id here (allows operating on all subscriptions)
+  # The provider uses ARM_SUBSCRIPTION_ID for authentication but can manage any subscription
+  # where the service principal has permissions
 }
 
 # # Provider Alias: Security Subscription


### PR DESCRIPTION
This is to get the roles from the root MG level rather than at subscription level

Else, we keep getting the following error even after we have granted the right roles at the right level to the ARM_CLIENT_ID_ADMIN SP.

Error: [DEBUG] Error assigning Subscription ID "***" to Management Group "mg-coruscant-management": unexpected status 400 (400 Bad Request) with response: {"error":{"code":"BadRequest","message":"Permission to write and delete on resources of type 'Microsoft.Authorization/roleAssignments' is required on the subscription or its ancestors.","details":"Subscription ID: '/subscriptions/***'"}}
